### PR TITLE
Replace lazy_static with once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,12 +291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "ordslice"
@@ -470,7 +464,7 @@ dependencies = [
  "clipboard-win",
  "error-code",
  "itertools",
- "lazy_static",
+ "once_cell",
  "ordslice",
  "preferences",
  "quickcheck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ winres = "0.1.12"
 
 [dev-dependencies]
 quickcheck = "1.0.3"
-lazy_static = "1.4.0"
+once_cell = "1.18.0"
 
 [profile.release]
 debug = true

--- a/src/clean_text/test.rs
+++ b/src/clean_text/test.rs
@@ -1,9 +1,10 @@
+use once_cell::sync::Lazy;
 use super::*;
 use quickcheck::quickcheck;
 
-lazy_static! {
-    pub static ref RE_LIST: Vec<RegexCleanerPair> = crate::settings::Settings::new().cleaners;
-}
+pub static RE_LIST: Lazy<Vec<RegexCleanerPair>> = Lazy::new(|| {
+    crate::settings::Settings::new().cleaners
+});
 
 pub fn clean_text_string<T: AsRef<str>>(raw: T, list: &[RegexCleanerPair]) -> String {
     clean_text(raw.as_ref(), list)

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@ use windows::Win32::{
 
 #[cfg(test)]
 #[macro_use]
-extern crate lazy_static;
 mod wide_string;
 mod window;
 use crate::window::*;


### PR DESCRIPTION
Fixes #16. I don't think `std::cell::OnceCell` does everything we need, hence the `once_cell` crate, but I might be wrong.